### PR TITLE
Improve name matching with Gemini adjudication

### DIFF
--- a/src/pages/Absensi/Absensi.tsx
+++ b/src/pages/Absensi/Absensi.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Upload, Users, CheckCircle, XCircle, Copy, Loader2, AlertCircle } from 'lucide-react';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 import Papa from 'papaparse';
 // import { getEmbeddings, cosineSim, topKCandidates, CandidateMatch } from '../../utils/embeddings';
 // import { computeChecksum, loadCachedEmbeddings, saveCachedEmbeddings } from '../../utils/cache';
-// import { adjudicateWithGemini, AiAdjudication } from '../../utils/ai_match';
+import { adjudicateWithGemini } from '../../utils/ai_match';
 
 // TypeScript Interfaces
 interface MenteeData {
@@ -268,9 +267,6 @@ const AttendanceTable: React.FC<AttendanceTableProps> = ({ results, onCopyBinary
   );
 };
 
-// Utility function untuk delay
-const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
-
 // Utility functions untuk name matching
 const normalizeString = (str: string): string => {
   return str
@@ -287,15 +283,14 @@ const extractNameVariations = (fullName: string): string[] => {
   // Add original normalized name
   variations.push(normalized);
 
-  // Split by common separators and extract parts
+  // Only add separated parts if the name itself is a single word
   const parts = fullName.split(/[_\-\s]+/).filter(part => part.length > 0);
-
-  parts.forEach(part => {
-    const normalizedPart = normalizeString(part);
+  if (parts.length === 1) {
+    const normalizedPart = normalizeString(parts[0]);
     if (normalizedPart.length > 2) {
       variations.push(normalizedPart);
     }
-  });
+  }
 
   // Extract name before program mention
   const beforeProgram = fullName.split(/_(web|ai|artificial)/i)[0];
@@ -303,10 +298,13 @@ const extractNameVariations = (fullName: string): string[] => {
     variations.push(normalizeString(beforeProgram));
   }
 
-  // Extract name from parentheses
+  // Extract name from parentheses (possible nickname)
   const parenthesesMatch = fullName.match(/\(([^)]+)\)/);
   if (parenthesesMatch) {
-    variations.push(normalizeString(parenthesesMatch[1]));
+    const nickname = normalizeString(parenthesesMatch[1]);
+    if (nickname.length > 2) {
+      variations.push(nickname);
+    }
   }
 
   return [...new Set(variations)]; // Remove duplicates
@@ -358,28 +356,21 @@ const findBestMatch = (zoomName: string, menteeNames: string[]): NameMatch | nul
   const zoomVariations = extractNameVariations(zoomName);
   let bestMatch: NameMatch | null = null;
 
-  // Menggunakan loop for...of untuk menghindari masalah 'never' type pada TypeScript
   for (const menteeName of menteeNames) {
     const menteeVariations = extractNameVariations(menteeName);
 
     for (const zoomVar of zoomVariations) {
       for (const menteeVar of menteeVariations) {
         const score = calculateNameSimilarity(zoomVar, menteeVar);
-        
+
         if (bestMatch === null || score > bestMatch.score) {
           bestMatch = { name: menteeName, score };
         }
       }
     }
-
-    const directScore = calculateNameSimilarity(zoomName, menteeName);
-    if (bestMatch === null || directScore > bestMatch.score) {
-      bestMatch = { name: menteeName, score: directScore };
-    }
   }
 
-  // Baris ini sekarang aman dan tidak akan error
-  return (bestMatch && bestMatch.score >= 0.75) ? bestMatch : null;
+  return bestMatch;
 };
 
 export const Absensi: React.FC = () => {
@@ -435,107 +426,6 @@ export const Absensi: React.FC = () => {
     }
   }, []);
 
-  // Enhanced batch name matching using Google Gemini AI
-  const batchMatchNamesWithAI = useCallback(async (
-    unmatchedZoomNames: string[],
-    menteeNames: string[]
-  ): Promise<Map<string, string | null>> => {
-    const results = new Map<string, string | null>();
-    const batchSize = 3; // Further reduced batch size
-    const delayBetweenBatches = 3000; // 3 second delay
-
-    try {
-      const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
-      if (!apiKey) {
-        throw new Error('Google Gemini API key not found in environment variables (VITE_GEMINI_API_KEY)');
-      }
-
-      const genAI = new GoogleGenerativeAI(apiKey);
-      const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
-
-      for (let i = 0; i < unmatchedZoomNames.length; i += batchSize) {
-        const batch = unmatchedZoomNames.slice(i, i + batchSize);
-        const batchProgress = ((i / unmatchedZoomNames.length) * 30) + 50;
-
-        setLoadingMessage(`AI name matching (batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(unmatchedZoomNames.length / batchSize)})...`);
-        setProgress(batchProgress);
-
-        try {
-          const prompt = `
-You are an expert at matching Indonesian names. Given these Zoom participant names and mentee names, find the best matches.
-
-Zoom names: ${JSON.stringify(batch)}
-Mentee names: ${JSON.stringify(menteeNames)}
-
-Rules for matching:
-1. Consider Indonesian naming conventions
-2. Handle variations like "Muhammad" vs "M", "Dwi" vs "Dwy"
-3. Ignore program suffixes like "_Web Development", "_AI", etc.
-4. Handle nicknames and shortened names
-5. Consider name order variations
-6. Match names in parentheses like "(Bella)" with "Bella"
-7. Handle underscore and dash separators
-
-Examples:
-- "Klaudio_AI" should match "Klaudio P.H"
-- "adinafadillah" should match "Adina Fadillah Balqis"
-- "bella_Web Dev (bella)" should match "Bela Putri Carolian Sembiring"
-- "vebri pratama_Web Development" should match "Vebri Pratama"
-- "FAUZAN DWI NUGROHO_Web Development" should match "Fauzan Dwi Nugroho"
-
-Return a JSON object where keys are Zoom names and values are the exact matching mentee names or null if no good match.
-
-Return ONLY the JSON object:`;
-
-          const result = await model.generateContent(prompt);
-          const responseText = result.response.text().trim();
-
-          let batchResults: Record<string, string | null>;
-          try {
-            const cleanedResponse = responseText.replace(/```json\n?|```\n?/g, '').trim();
-            batchResults = JSON.parse(cleanedResponse);
-          } catch {
-            console.warn('Failed to parse AI response:', responseText);
-            batchResults = {};
-            batch.forEach(name => {
-              batchResults[name] = null;
-            });
-          }
-
-          // Validate and store results
-          Object.entries(batchResults).forEach(([zoomName, matchedName]) => {
-            if (matchedName && menteeNames.includes(matchedName)) {
-              results.set(zoomName, matchedName);
-            } else {
-              results.set(zoomName, null);
-            }
-          });
-
-        } catch (batchError) {
-          console.warn(`AI batch failed for batch ${Math.floor(i / batchSize) + 1}:`, batchError);
-          batch.forEach(name => {
-            results.set(name, null);
-          });
-
-          if (batchError instanceof Error && batchError.message.includes('429')) {
-            setLoadingMessage('Rate limit reached, waiting...');
-            await delay(8000); // 8 second delay for rate limiting
-          }
-        }
-
-        if (i + batchSize < unmatchedZoomNames.length) {
-          await delay(delayBetweenBatches);
-        }
-      }
-
-      return results;
-
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown AI error';
-      console.error('AI batch matching error:', error);
-      throw new Error(`AI batch matching failed: ${errorMessage}`);
-    }
-  }, []);
 
   // Enhanced CSV processing with improved name matching
   const handleFileUpload = useCallback(async (file: File): Promise<void> => {
@@ -580,49 +470,46 @@ Return ONLY the JSON object:`;
       setProgress(25);
 
       const attendanceResults: AttendanceResult[] = [];
-      const menteeNames = menteeData.map(m => m.nama);
       const zoomNameToParticipant = new Map<string, ZoomParticipant>();
 
       zoomData.forEach(participant => {
         zoomNameToParticipant.set(participant.nama, participant);
       });
 
-      setLoadingMessage('Melakukan pencocokan nama dengan algoritma enhanced...');
+      setLoadingMessage('Melakukan pencocokan nama dengan AI...');
       setProgress(30);
 
-      // Enhanced exact matching
+      const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
+      if (!apiKey) {
+        throw new Error('Google Gemini API key not found in environment variables (VITE_GEMINI_API_KEY)');
+      }
+
       const matchedZoomNames = new Set<string>();
 
-      menteeData.forEach((mentee, index) => {
-        const progressPercent = 30 + ((index / menteeData.length) * 15);
+      for (const [index, mentee] of menteeData.entries()) {
+        const progressPercent = 30 + ((index / menteeData.length) * 40);
         setProgress(progressPercent);
 
         let matchedParticipant: ZoomParticipant | null = null;
         let matchedZoomName: string | null = null;
+        let matchMeta: AttendanceResult['matchMeta'] = { source: 'none' };
 
-        // Try enhanced matching algorithm
-        const bestMatch = findBestMatch(mentee.nama, Array.from(zoomNameToParticipant.keys()));
+        const candidate = findBestMatch(
+          mentee.nama,
+          Array.from(zoomNameToParticipant.keys()).filter(name => !matchedZoomNames.has(name))
+        );
 
-        if (bestMatch && bestMatch.score >= 0.7) {
-          matchedParticipant = zoomNameToParticipant.get(bestMatch.name) || null;
-          matchedZoomName = bestMatch.name;
-          if (matchedParticipant) {
-            matchedZoomNames.add(bestMatch.name);
-          }
-        }
-
-        // Fallback to simple contains check
-        if (!matchedParticipant) {
-          for (const [zoomName, participant] of zoomNameToParticipant.entries()) {
-            if (matchedZoomNames.has(zoomName)) continue;
-
-            const similarity = calculateNameSimilarity(mentee.nama, zoomName);
-            if (similarity >= 0.6) {
-              matchedParticipant = participant;
-              matchedZoomName = zoomName;
-              matchedZoomNames.add(zoomName);
-              break;
+        if (candidate && candidate.score >= 0.2) {
+          try {
+            const aiResult = await adjudicateWithGemini(apiKey, candidate.name, [mentee.nama]);
+            if (aiResult.bestMatch) {
+              matchedParticipant = zoomNameToParticipant.get(candidate.name) || null;
+              matchedZoomName = candidate.name;
+              matchedZoomNames.add(candidate.name);
+              matchMeta = { source: 'ai', score: candidate.score, confidence: aiResult.confidence };
             }
+          } catch (aiErr) {
+            console.warn('AI adjudication failed:', aiErr);
           }
         }
 
@@ -633,59 +520,12 @@ Return ONLY the JSON object:`;
           mentee,
           durasi,
           status,
-          matchedName: matchedZoomName && matchedZoomName !== mentee.nama ? matchedZoomName : undefined
+          matchedName: matchedZoomName && matchedZoomName !== mentee.nama ? matchedZoomName : undefined,
+          matchMeta
         });
-      });
-
-      setProgress(45);
-
-      // Collect truly unmatched zoom names for AI processing
-      const unmatchedZoomNames = Array.from(zoomNameToParticipant.keys())
-        .filter(name => !matchedZoomNames.has(name))
-        .filter(name => {
-          // Filter out obvious non-mentee entries
-          const normalized = normalizeString(name);
-          return !normalized.includes('infinite learning') &&
-            !normalized.includes('il ') &&
-            normalized.length > 3;
-        });
-
-      // AI matching for remaining unmatched names
-      if (unmatchedZoomNames.length > 0) {
-        setLoadingMessage(`Menggunakan AI untuk ${unmatchedZoomNames.length} nama yang belum cocok...`);
-
-        try {
-          const aiMatches = await batchMatchNamesWithAI(unmatchedZoomNames, menteeNames);
-
-          setLoadingMessage('Menerapkan hasil AI matching...');
-          setProgress(80);
-
-          // Apply AI matches to unmatched mentees
-          aiMatches.forEach((matchedMenteeName, zoomName) => {
-            if (matchedMenteeName) {
-              const zoomParticipant = zoomNameToParticipant.get(zoomName);
-              const resultIndex = attendanceResults.findIndex(r =>
-                r.mentee.nama === matchedMenteeName && r.durasi === 0
-              );
-
-              if (zoomParticipant && resultIndex !== -1) {
-                const durasi = zoomParticipant.durasi || 0;
-                const status: 0 | 1 = durasi >= 30 ? 1 : 0;
-
-                attendanceResults[resultIndex] = {
-                  ...attendanceResults[resultIndex],
-                  durasi,
-                  status,
-                  matchedName: zoomName !== matchedMenteeName ? zoomName : undefined
-                };
-              }
-            }
-          });
-        } catch (aiError) {
-          console.warn('AI matching failed:', aiError);
-          setError(`Warning: AI matching failed - ${aiError instanceof Error ? aiError.message : 'Unknown AI error'}\n\nContinuing with enhanced algorithm matches only.`);
-        }
       }
+
+      setProgress(80);
 
       setLoadingMessage('Menghitung statistik...');
       setProgress(90);
@@ -712,7 +552,7 @@ Return ONLY the JSON object:`;
     } finally {
       setIsProcessing(false);
     }
-  }, [loadMenteeData, batchMatchNamesWithAI]);
+  }, [loadMenteeData]);
 
   // Copy binary results to clipboard
   const handleCopyBinary = useCallback((): void => {


### PR DESCRIPTION
## Summary
- refine name normalization to avoid single-token matches
- verify each candidate using Gemini and match each participant only once

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d61e76e4832380bf4e85c5252515